### PR TITLE
Add basic backend and Flutter tests

### DIFF
--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -1,0 +1,53 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models', () => ({
+  Car: {
+    create: jest.fn(),
+    findOne: jest.fn(),
+  },
+  Repair: {},
+  WashLog: {}
+}));
+
+const { Car } = require('../models');
+const carsRouter = require('../routes/cars');
+
+const app = express();
+app.use(express.json());
+app.get('/health', (req, res) => {
+  res.json({ status: 'OK' });
+});
+app.use('/api/cars', carsRouter);
+
+describe('Backend API routes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('GET /health returns OK', async () => {
+    const res = await request(app).get('/health');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'OK' });
+  });
+
+  test('POST /api/cars creates a car', async () => {
+    const carData = { plate_number: 'abc123', vin: 'vin1234567890123' };
+    Car.create.mockResolvedValue({ id: 1, ...carData });
+
+    const res = await request(app).post('/api/cars').send(carData);
+    expect(res.statusCode).toBe(201);
+    expect(Car.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plate_number: 'ABC123',
+        vin: 'VIN1234567890123'
+      })
+    );
+    expect(res.body.success).toBe(true);
+  });
+
+  test('GET /api/cars/:plate_number not found', async () => {
+    Car.findOne.mockResolvedValue(null);
+    const res = await request(app).get('/api/cars/ABC123');
+    expect(res.statusCode).toBe(404);
+    expect(res.body.code).toBe('CAR_NOT_FOUND');
+  });
+});

--- a/frontend/test/car_provider_test.dart
+++ b/frontend/test/car_provider_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:car_maintenance_app/providers/car_provider.dart';
+import 'package:car_maintenance_app/models/car.dart';
+
+void main() {
+  group('CarProvider', () {
+    test('isPlateNumberExists returns true when car exists', () {
+      final provider = CarProvider();
+      provider.selectCar(
+        Car(plateNumber: 'ABC123', vin: 'VIN1234567890123'),
+      );
+      // After selecting, provider.selectedCar is set
+      expect(provider.selectedCar?.plateNumber, 'ABC123');
+      expect(provider.isPlateNumberExists('abc123'), isTrue);
+    });
+
+    test('clearSelectedCar resets selected car', () {
+      final provider = CarProvider();
+      provider.selectCar(Car(plateNumber: 'A', vin: 'V'));
+      provider.clearSelectedCar();
+      expect(provider.selectedCar, isNull);
+    });
+  });
+}

--- a/frontend/test/home_page_test.dart
+++ b/frontend/test/home_page_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:car_maintenance_app/providers/car_provider.dart';
+import 'package:car_maintenance_app/pages/home_page.dart';
+import 'package:car_maintenance_app/config/app_config.dart';
+
+void main() {
+  testWidgets('HomePage shows app title and FAB', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider(
+          create: (_) => CarProvider(),
+          child: const HomePage(),
+        ),
+      ),
+    );
+
+    expect(find.text(AppConfig.appName), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce Jest/Supertest tests for backend routes
- add provider and widget tests for Flutter app

## Testing
- `npm test --silent` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864be84e6e083238bdc5eb90a1476f0